### PR TITLE
Update image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.7-stretch
+FROM golang:1.20.3-bullseye
 
 ENV GITHUB_COMMENT_VERSION=v0.1.1
 


### PR DESCRIPTION
# WHAT
Use bullseye image

```
docker build -t action-github-comment .
[+] Building 1.8s (10/10) FINISHED
 => [internal] load build definition from Dockerfile                                                               0.0s
 => => transferring dockerfile: 74B                                                                                0.0s
 => [internal] load .dockerignore                                                                                  0.0s
 => => transferring context: 2B                                                                                    0.0s
 => [internal] load metadata for docker.io/library/golang:1.20.3-bullseye                                          1.8s
 => [internal] load build context                                                                                  0.0s
 => => transferring context: 72B                                                                                   0.0s
 => [1/5] FROM docker.io/library/golang:1.20.3-bullseye@sha256:595c9af0430dd84bad33020e7e9e328af4bd1a1aabd46a03b5  0.0s
 => CACHED [2/5] RUN apt-get update && apt-get install -y --no-install-recommends         ca-certificates          0.0s
 => CACHED [3/5] RUN mkdir -p /tmp/github-comment     && cd /tmp/github-comment     && wget https://github.com/b4  0.0s
 => CACHED [4/5] COPY entrypoint.sh /entrypoint.sh                                                                 0.0s
 => CACHED [5/5] RUN chmod +x /entrypoint.sh                                                                       0.0s
 => exporting to image                                                                                             0.0s
 => => exporting layers                                                                                            0.0s
 => => writing image sha256:cc0a58596002ecd0e8aa80c84d407cdc8907097366cbe0bc463fb3226d86aaaa                       0.0s
 => => naming to docker.io/library/action-github-comment                                                           0.0s
```

# WHY
Because stretch have reached its EoL